### PR TITLE
Debug flutter transfer and create release zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ CSVからExcelへの転記と、ExcelからPDFへの変換を行います。Wind
 
 注意
 - PDF変換にはMicrosoft Excel（デスクトップ版）が必要
-- バックエンドは `kinten_backend.exe` 同梱のためPythonは不要
+- バックエンドは `kinten_backend.exe` 同梱のためPythonは不要（同時に `backend/` ソースも同梱され、フォールバックとして利用可能）
 
 ## 配布パッケージ構成
 ```
@@ -78,7 +78,7 @@ kinten/
   ```bash
   bash scripts/sync_dist_macos.sh
   ```
-- 配布ZIPの作成（Python不要のバックエンド同梱）
+- 配布ZIPの作成（Python不要のバックエンド同梱 or backendソース同梱）
   ```bash
   bash scripts/package_macos.sh
   ```

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,0 +1,14 @@
+# リリースノート
+
+## ver1.0.1
+- Flutter フロントエンドのバージョンを `1.0.1+2` に更新（`frontend/pubspec.yaml`）
+- macOS 配布用スクリプト `scripts/package_macos.sh` を追加
+  - `dist/` 同期後、`kinten.app` と `backend/` 一式、`templates/`、`input/`、`output/`、`requirements.txt` を同梱
+  - `package/kinten.zip` を作成
+- 転記処理の Python 実行経路を確認
+  - `frontend/lib/providers/app_state_provider.dart` は `backend/` を `PYTHONPATH` に追加し、ランタイムに Python または `.venv/bin/python` を解決
+  - Windows では `kinten_backend.exe` があれば優先実行（Python不要）
+
+インストール/実行上の注意:
+- macOS では同梱の `backend/` と `requirements.txt` を利用し、初回のみ仮想環境の作成と依存導入が必要な場合があります（`pywin32` は macOS では無視されます）。
+- Windows では `kinten_backend.exe` 同梱により Python 不要。

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -2,7 +2,7 @@ name: kinten
 description: "freee勤怠CSVをExcel勤怠表テンプレートへ自動転記するデスクトップアプリ"
 publish_to: 'none'
 
-version: 1.0.0+1
+version: 1.0.1+2
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/kinten_backend.spec
+++ b/kinten_backend.spec
@@ -2,7 +2,7 @@
 
 
 a = Analysis(
-    ['backend\\main.py'],
+    ['backend/main.py'],
     pathex=[],
     binaries=[],
     datas=[

--- a/scripts/package_macos.sh
+++ b/scripts/package_macos.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# macOS packaging script for Kinten
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FRONTEND_DIR="$ROOT_DIR/frontend"
+DIST_DIR="$ROOT_DIR/dist"
+PKG_DIR="$ROOT_DIR/package"
+PKG_ROOT="$PKG_DIR/kinten"
+APP_SRC="$FRONTEND_DIR/build/macos/Build/Products/Release/kinten.app"
+
+echo "[pkg-mac] ROOT_DIR=$ROOT_DIR"
+
+if [[ "${1:-}" != "--skip-build" ]]; then
+  echo "[pkg-mac] Build Flutter (macOS)"
+  pushd "$FRONTEND_DIR" >/dev/null
+  flutter clean
+  flutter pub get
+  flutter build macos --release
+  popd >/dev/null
+
+  echo "[pkg-mac] Sync dist"
+  bash "$ROOT_DIR/scripts/sync_dist_macos.sh"
+fi
+
+# Prepare package root
+rm -rf "$PKG_ROOT"
+mkdir -p "$PKG_ROOT"
+
+# Copy app bundle
+echo "[pkg-mac] Copy app bundle"
+if [[ ! -d "$DIST_DIR/macos/kinten.app" ]]; then
+  # fallback to build dir
+  if [[ -d "$APP_SRC" ]]; then
+    mkdir -p "$DIST_DIR/macos"
+    rsync -a "$APP_SRC" "$DIST_DIR/macos/"
+  else
+    echo "[pkg-mac] kinten.app not found. Build first."
+    exit 1
+  fi
+fi
+rsync -a "$DIST_DIR/macos/kinten.app" "$PKG_ROOT/"
+
+# Copy backend sources and assets
+echo "[pkg-mac] Copy backend/templates/input/output/requirements"
+rsync -a "$ROOT_DIR/backend" "$PKG_ROOT/"
+rsync -a "$ROOT_DIR/templates" "$PKG_ROOT/"
+mkdir -p "$PKG_ROOT/input" "$PKG_ROOT/output"
+cp -f "$ROOT_DIR/requirements.txt" "$PKG_ROOT/"
+
+# Optional: include prebuilt backend if exists
+if [[ -f "$DIST_DIR/kinten_backend" ]]; then
+  echo "[pkg-mac] Copy prebuilt backend binary"
+  cp -f "$DIST_DIR/kinten_backend" "$PKG_ROOT/"
+fi
+
+# Create zip
+mkdir -p "$PKG_DIR"
+ZIP_PATH="$PKG_DIR/kinten.zip"
+rm -f "$ZIP_PATH"
+
+echo "[pkg-mac] Create zip -> $ZIP_PATH"
+pushd "$PKG_DIR" >/dev/null
+zip -r9 "$(basename "$ZIP_PATH")" "$(basename "$PKG_ROOT")"
+popd >/dev/null
+
+echo "[pkg-mac] Done: $ZIP_PATH"

--- a/scripts/package_windows.ps1
+++ b/scripts/package_windows.ps1
@@ -81,19 +81,23 @@ if (Test-Path (Join-Path $DIST 'kinten_backend.exe')) {
   Copy-Item -Force (Join-Path $DIST 'kinten_backend.exe') (Join-Path $PKG_ROOT 'kinten_backend.exe')
 }
 
+# 5.1) バックエンドソース一式も同梱（FlutterからPython直呼びのフォールバック用）
+Write-Host "[pkg-win] Copy backend source folder"
+Copy-Item -Recurse -Force (Join-Path $ROOT 'backend') $PKG_ROOT
+ 
 # 6) テンプレート/入出力/requirements
 Write-Host "[pkg-win] Copy templates + create input/output"
 Copy-Item -Recurse -Force (Join-Path $ROOT 'templates') $PKG_ROOT
 New-Item -ItemType Directory -Force -Path (Join-Path $PKG_ROOT 'input') | Out-Null
 New-Item -ItemType Directory -Force -Path (Join-Path $PKG_ROOT 'output') | Out-Null
 Copy-Item -Force (Join-Path $ROOT 'requirements.txt') $PKG_ROOT
-
+ 
 # 7) zip 作成
 Write-Host "[pkg-win] Create zip"
 New-Item -ItemType Directory -Force -Path $PKG_DIR | Out-Null
 $zipPath = Join-Path $PKG_DIR 'kinten_windows.zip'
 if (Test-Path $zipPath) { Remove-Item -Force $zipPath }
 Compress-Archive -Path (Join-Path $PKG_ROOT '*') -DestinationPath $zipPath -Force
-
+ 
 Write-Host "[pkg-win] Done: $zipPath"
 


### PR DESCRIPTION
Ensure Python backend files are consistently included in macOS and Windows release packages to fix transfer errors and update to version 1.0.1.

The Flutter application calls Python scripts for transfer operations, but the `backend/` directory containing these scripts was not always bundled with the distributed application, leading to `ImportError` at runtime. This PR ensures `backend/` is included in both macOS and Windows packages and provides updated packaging scripts.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0dd4a30-72f1-4389-a9ea-abdbc6aa773e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0dd4a30-72f1-4389-a9ea-abdbc6aa773e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

