### PR TITLE
Automate 1.0.1 release with github actions

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -50,19 +50,19 @@ jobs:
           name: kinten_windows
           path: package/kinten_windows.zip
 
-      - name: Move v1.0.0 tag to HEAD (force)
+      - name: Move v1.0.1 tag to HEAD (force)
         shell: pwsh
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -f v1.0.0
-          git push -f origin v1.0.0
+          git tag -f v1.0.1
+          git push -f origin v1.0.1
 
-      - name: Create or update GitHub Release for v1.0.0
+      - name: Create or update GitHub Release for v1.0.1
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v1.0.0
-          name: kinten v1.0.0
+          tag_name: v1.0.1
+          name: kinten v1.0.1
           files: package/kinten_windows.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update Windows build workflow to enable v1.0.1 release via GitHub Actions.

---
<a href="https://cursor.com/background-agent?bcId=bc-85e3fa52-94cb-45b0-a55b-680c626c058e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-85e3fa52-94cb-45b0-a55b-680c626c058e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

